### PR TITLE
prepare_app called on every request

### DIFF
--- a/lib/OX/Application/Role/Sugar.pm
+++ b/lib/OX/Application/Role/Sugar.pm
@@ -90,7 +90,7 @@ around to_app => sub {
     my $self = shift;
 
     return $self->$orig(@_)
-        unless $self->meta->has_middleware_dependencies;
+        unless $self->meta->needs_reresolve;
 
     # need to re-resolve for every request, to ensure that middleware
     # dependencies are correct - otherwise, a middleware that depends on a

--- a/lib/OX/Meta/Middleware.pm
+++ b/lib/OX/Meta/Middleware.pm
@@ -14,6 +14,12 @@ has dependencies => (
     default => sub { +{} },
 );
 
+has needs_reresolve => (
+    is      => 'ro',
+    isa     => 'Bool',
+    default => '0',
+);
+
 has condition => (
     is  => 'ro',
     isa => 'CodeRef',

--- a/lib/OX/Meta/Role/HasMiddleware.pm
+++ b/lib/OX/Meta/Role/HasMiddleware.pm
@@ -38,6 +38,7 @@ sub add_middleware {
         my $meta = $self->name->meta;
         my $needs_reresolve = 0;
         foreach my $dep (values %{$args{dependencies}} ) {
+            next if blessed($dep) && $dep->isa('Bread::Board::Literal');
             my $attrib = $meta->get_attribute($dep);
             if (!$attrib->lifecycle || $attrib->lifecycle ne 'Singleton') {
                 $needs_reresolve = 1;

--- a/t/middleware_prepare_app.t
+++ b/t/middleware_prepare_app.t
@@ -35,7 +35,7 @@ my %calls;
     package Foo;
     use OX;
 
-    has 'foo' => ( is=>'ro',isa=>'Str',value=>'a value');
+    has 'foo' => ( is=>'ro',isa=>'Str',value=>'a value', lifecycle=>'Singleton');
 
     router as {
         wrap 'Foo::Middleware' => ( some_dependency=>'foo' );

--- a/t/middleware_prepare_app.t
+++ b/t/middleware_prepare_app.t
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Plack::Test;
+
+use HTTP::Request;
+
+my %calls;
+
+{
+    package Foo::Middleware;
+    use Moose;
+
+    extends 'Plack::Middleware';
+
+    sub prepare_app {
+        my ( $self ) = @_;
+        $calls{ 'prepare_app' }++;
+    }
+
+    sub call {
+        my $self = shift;
+        my ($env) = @_;
+
+        $calls{ 'call' }++;
+
+        return $self->app->($env);
+    }
+}
+
+{
+    package Foo;
+    use OX;
+
+    router as {
+        wrap 'Foo::Middleware';
+        route '/' => sub { "root" } => (
+            name => 'root',
+        );
+    }
+}
+
+my $app = Foo->new->to_app;
+
+test_psgi
+    app    => $app,
+    client => sub {
+        my $cb = shift;
+        {
+            my $req = HTTP::Request->new(GET => 'http://localhost/');
+            my $res1 = $cb->($req);
+            my $res2 = $cb->($req);
+        }
+    };
+test_psgi
+    app    => $app,
+    client => sub {
+        my $cb = shift;
+        {
+            my $req = HTTP::Request->new(GET => 'http://localhost/');
+            my $res1 = $cb->($req);
+            my $res2 = $cb->($req);
+        }
+    };
+
+is($calls{call},4,'call was called 4 times');
+is($calls{prepare_app},1,'prepare_app was called once');
+
+done_testing;

--- a/t/middleware_prepare_app.t
+++ b/t/middleware_prepare_app.t
@@ -14,6 +14,8 @@ my %calls;
 
     extends 'Plack::Middleware';
 
+    has 'some_dependency' => (is=>'ro',isa=>'Str',required=>1);
+
     sub prepare_app {
         my ( $self ) = @_;
         $calls{ 'prepare_app' }++;
@@ -33,8 +35,10 @@ my %calls;
     package Foo;
     use OX;
 
+    has 'foo' => ( is=>'ro',isa=>'Str',value=>'a value');
+
     router as {
-        wrap 'Foo::Middleware';
+        wrap 'Foo::Middleware' => ( some_dependency=>'foo' );
         route '/' => sub { "root" } => (
             name => 'root',
         );


### PR DESCRIPTION
When a Middleware has a dependency (resolved via Bread::Board), this Middlewares prepare_app method will be called on every request. This feels like a bug to me.

This pull request adds a test that illustrates the problem:
t/middleware_prepare_app.t

But there is a comment in the "guilty" code:
OX::Application::Role::Sugar -> around 'to_app'  lines 88ff

The comment seems to indicate that Middlewares with dependencies need to be re-evaled on each request. I don't know enough OX internals to understand the issue here, but it makes complex middlewares rather unusable (and thus OX...)
Even Plack::Middleware::Session will not cache its state/store...

When I tried to remove the around to_app code, my test works, but 
t/middleware_dependencies.t 
failed

Any ideas what to do?
