### PR TITLE
OX can't inherit from a Bread::Board::Declare class

### DIFF
--- a/t/inherit-bread-board.t
+++ b/t/inherit-bread-board.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+	package Container;
+	use Moose;
+	use Bread::Board::Declare;
+}
+{
+	package App;
+	use OX;
+	extends 'Container';
+}
+
+new_ok App;
+
+done_testing;


### PR DESCRIPTION
This seems like a bug to me, test included but no fix
