### PR TITLE
Fix Dist::Zilla PkgVersion "no blank line" warnings

### DIFF
--- a/lib/Bread/Board/LifeCycle/Request.pm
+++ b/lib/Bread/Board/LifeCycle/Request.pm
@@ -1,4 +1,5 @@
 package Bread::Board::LifeCycle::Request;
+
 use Moose::Role;
 use namespace::autoclean;
 # ABSTRACT: lifecycle for request-scoped services

--- a/lib/OX.pm
+++ b/lib/OX.pm
@@ -1,4 +1,5 @@
 package OX;
+
 use Moose::Exporter;
 use 5.010;
 # ABSTRACT: the hardest working two letters in Perl

--- a/lib/OX/Application.pm
+++ b/lib/OX/Application.pm
@@ -1,4 +1,5 @@
 package OX::Application;
+
 use Moose 2.0200;
 use namespace::autoclean;
 # ABSTRACT: base class for OX applications

--- a/lib/OX/Application/Role/Request.pm
+++ b/lib/OX/Application/Role/Request.pm
@@ -1,4 +1,5 @@
 package OX::Application::Role::Request;
+
 use Moose::Role;
 use namespace::autoclean;
 # ABSTRACT: application role to allow the use of request and response objects

--- a/lib/OX/Application/Role/RouteBuilder.pm
+++ b/lib/OX/Application/Role/RouteBuilder.pm
@@ -1,4 +1,5 @@
 package OX::Application::Role::RouteBuilder;
+
 use Moose::Role;
 use namespace::autoclean;
 # ABSTRACT: application role to configure a router based on a static description

--- a/lib/OX/Application/Role/Router.pm
+++ b/lib/OX/Application/Role/Router.pm
@@ -1,4 +1,5 @@
 package OX::Application::Role::Router;
+
 use Moose::Role;
 use namespace::autoclean;
 # ABSTRACT: base role for applications with routers

--- a/lib/OX/Application/Role/Router/Path/Router.pm
+++ b/lib/OX/Application/Role/Router/Path/Router.pm
@@ -1,4 +1,5 @@
 package OX::Application::Role::Router::Path::Router;
+
 use Moose::Role;
 use namespace::autoclean;
 # ABSTRACT: implementation of OX::Application::Role::Router which uses Path::Router

--- a/lib/OX/Application/Role/RouterConfig.pm
+++ b/lib/OX/Application/Role/RouterConfig.pm
@@ -1,4 +1,5 @@
 package OX::Application::Role::RouterConfig;
+
 use Moose::Role;
 use namespace::autoclean;
 # ABSTRACT: adds some common shortcuts to route declarations from OX::Application::Role::RouteBuilder

--- a/lib/OX/Application/Role/Sugar.pm
+++ b/lib/OX/Application/Role/Sugar.pm
@@ -1,4 +1,5 @@
 package OX::Application::Role::Sugar;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Conflict.pm
+++ b/lib/OX/Meta/Conflict.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Conflict;
+
 use Moose;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Middleware.pm
+++ b/lib/OX/Meta/Middleware.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Middleware;
+
 use Moose;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Mount.pm
+++ b/lib/OX/Meta/Mount.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Mount;
+
 use Moose;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Mount/App.pm
+++ b/lib/OX/Meta/Mount/App.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Mount::App;
+
 use Moose;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Mount/Class.pm
+++ b/lib/OX/Meta/Mount/Class.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Mount::Class;
+
 use Moose;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/Application.pm
+++ b/lib/OX/Meta/Role/Application.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::Application;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/Application/ToClass.pm
+++ b/lib/OX/Meta/Role/Application/ToClass.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::Application::ToClass;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/Application/ToInstance.pm
+++ b/lib/OX/Meta/Role/Application/ToInstance.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::Application::ToInstance;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/Application/ToRole.pm
+++ b/lib/OX/Meta/Role/Application/ToRole.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::Application::ToRole;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/Class.pm
+++ b/lib/OX/Meta/Role/Class.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::Class;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/Composite.pm
+++ b/lib/OX/Meta/Role/Composite.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::Composite;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/HasMiddleware.pm
+++ b/lib/OX/Meta/Role/HasMiddleware.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::HasMiddleware;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/HasRouteBuilders.pm
+++ b/lib/OX/Meta/Role/HasRouteBuilders.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::HasRouteBuilders;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/HasRoutes.pm
+++ b/lib/OX/Meta/Role/HasRoutes.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::HasRoutes;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/Path.pm
+++ b/lib/OX/Meta/Role/Path.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::Path;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Role/Role.pm
+++ b/lib/OX/Meta/Role/Role.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Role::Role;
+
 use Moose::Role;
 use namespace::autoclean;
 

--- a/lib/OX/Meta/Route.pm
+++ b/lib/OX/Meta/Route.pm
@@ -1,4 +1,5 @@
 package OX::Meta::Route;
+
 use Moose;
 use namespace::autoclean;
 

--- a/lib/OX/Request.pm
+++ b/lib/OX/Request.pm
@@ -1,4 +1,5 @@
 package OX::Request;
+
 use Moose;
 use namespace::autoclean;
 # ABSTRACT: request object for OX

--- a/lib/OX/Response.pm
+++ b/lib/OX/Response.pm
@@ -1,4 +1,5 @@
 package OX::Response;
+
 use Moose;
 use namespace::autoclean;
 # ABSTRACT: response object for OX

--- a/lib/OX/Role.pm
+++ b/lib/OX/Role.pm
@@ -1,4 +1,5 @@
 package OX::Role;
+
 use Moose::Exporter;
 use 5.010;
 # ABSTRACT: declare roles for your OX applications

--- a/lib/OX/RouteBuilder.pm
+++ b/lib/OX/RouteBuilder.pm
@@ -1,4 +1,5 @@
 package OX::RouteBuilder;
+
 use Moose::Role;
 use namespace::autoclean;
 # ABSTRACT: abstract role for classes that turn configuration into a route

--- a/lib/OX/RouteBuilder/Code.pm
+++ b/lib/OX/RouteBuilder/Code.pm
@@ -1,4 +1,5 @@
 package OX::RouteBuilder::Code;
+
 use Moose;
 use namespace::autoclean;
 # ABSTRACT: OX::RouteBuilder which routes to a coderef

--- a/lib/OX/RouteBuilder/ControllerAction.pm
+++ b/lib/OX/RouteBuilder/ControllerAction.pm
@@ -1,4 +1,5 @@
 package OX::RouteBuilder::ControllerAction;
+
 use Moose;
 use namespace::autoclean;
 # ABSTRACT: OX::RouteBuilder which routes to an action method in a controller class

--- a/lib/OX/RouteBuilder/HTTPMethod.pm
+++ b/lib/OX/RouteBuilder/HTTPMethod.pm
@@ -1,4 +1,5 @@
 package OX::RouteBuilder::HTTPMethod;
+
 use Moose;
 use namespace::autoclean;
 # ABSTRACT: OX::RouteBuilder which routes to a method in a controller based on the HTTP method

--- a/lib/OX/Types.pm
+++ b/lib/OX/Types.pm
@@ -1,4 +1,5 @@
 package OX::Types;
+
 use strict;
 use warnings;
 

--- a/lib/OX/Util.pm
+++ b/lib/OX/Util.pm
@@ -1,4 +1,5 @@
 package OX::Util;
+
 use strict;
 use warnings;
 


### PR DESCRIPTION
When running the tests via `dzil test`, I found that the `Dist::Zilla` plugin `PkgVersion` gave several warnings like this:

```
[@DOY/PkgVersion] no blank line for $VERSION after package OX statement in lib/OX.pm line 1
```

What this means is that `PkgVersion` expects an empty line after the `package` statement in each module file.

This change adds this blank line to all of the affected files, hence removing the warnings and hence the distraction when running the test suite.

This pull request is submitted in the hope that it is useful. If you want anything changed, please let me know and I'll be more than happy to update and resubmit as necessary.