### PR TITLE
Remove link to old CPAN Ratings site

### DIFF
--- a/lib/OX.pm
+++ b/lib/OX.pm
@@ -551,10 +551,6 @@ L<https://github.com/iinteractive/OX>
 
 L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=OX>
 
-=item * CPAN Ratings
-
-L<http://cpanratings.perl.org/d/OX>
-
 =back
 
 =for Pod::Coverage


### PR DESCRIPTION
As noticed in #22, the cpanratings link is a redirect.  The CPAN Ratings site is no longer online and [was set to read-only in 2018](https://log.perl.org/2018/06/cpan-ratings-read-only.html). See also [the discussion about removing CPAN Ratings MetaCPAN](https://github.com/metacpan/metacpan-web/issues/1653). Since the site is no longer available, it seems a good idea to remove the link to it from the OX documentation.

Note that implementing this change would also resolve the issue mentioned in #22.